### PR TITLE
mo can now source a script before parsing templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ diagnostic.test
 tests/*.diff
 spec/
 spec-runner/
-demo/sourcing.vars

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ diagnostic.test
 tests/*.diff
 spec/
 spec-runner/
+demo/sourcing.vars

--- a/demo/sourcing
+++ b/demo/sourcing
@@ -4,11 +4,6 @@
 
 cd "$(dirname "$0")" # Go to the script's directory
 
-cat <<EOF >sourcing.vars
-export NAME="Alex"
-export ARRAY=( AAA BBB CCC )
-EOF
-
 cat <<EOF | ../mo --source=sourcing.vars
 Hello, my name is {{NAME}}.
 And this is ARRAY's conntents:

--- a/demo/sourcing
+++ b/demo/sourcing
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This sources a simple script with the env. variables needed for the template.
+
+cd "$(dirname "$0")" # Go to the script's directory
+
+cat <<EOF >sourcing.vars
+export NAME="Alex"
+export ARRAY=( AAA BBB CCC )
+EOF
+
+cat <<EOF | ../mo --source=sourcing.vars
+Hello, my name is {{NAME}}.
+And this is ARRAY's conntents:
+{{#ARRAY}}
+    * {{.}}
+{{/ARRAY}}
+EOF

--- a/demo/sourcing.vars
+++ b/demo/sourcing.vars
@@ -1,0 +1,2 @@
+export NAME="Alex"
+export ARRAY=( AAA BBB CCC )

--- a/mo
+++ b/mo
@@ -29,25 +29,38 @@
 mo() (
     # This function executes in a subshell so IFS is reset.
     # Namespace this variable so we don't conflict with desired values.
-    local moContent
+    local moContent files=()
 
     IFS=$' \n\t'
 
     if [[ $# -gt 0 ]]; then
-        case "$1" in
-            -h|--h|--he|--hel|--help)
-                moUsage "$0"
-                exit 0
-                ;;
+        for arg in "$@"; do
+            case "$arg" in
+                -h|--h|--he|--hel|--help)
+                    moUsage "$0"
+                    exit 0
+                    ;;
 
-            --source=*)
-                . "${1#--source=}"
-                shift 1
-                ;;
-        esac
+                --source=*)
+                    local f2source="${1#--source=}"
+                    if [[ -f "$f2source" ]]; then
+                        . "$f2source"
+                        continue
+                    else
+                        printf "%s: %s: %s\n"\
+                               "$0" "$f2source" "No such file" >&2
+                        exit 1
+                    fi
+                    ;;
+
+                *) # Every arg that is not a flag or a option should be a file
+                    files+=("$arg")
+                    ;;
+            esac
+        done
     fi
 
-    moGetContent moContent "$@"
+    moGetContent moContent "${files[@]}"
     moParse "$moContent" "" true
 )
 

--- a/mo
+++ b/mo
@@ -21,7 +21,9 @@
 #
 # $0 - Name of the mo file, used for getting the help message.
 # $* - Filenames to parse.  Can use -h or --help as the only option
-#      in order to show a help message.
+#      in order to show a help message. Additionaly, --source=file
+#      can be passed so that mo sources the file before parsing
+#      the filenames.
 #
 # Returns nothing.
 mo() (
@@ -30,12 +32,17 @@ mo() (
     local moContent
 
     IFS=$' \n\t'
-    
+
     if [[ $# -gt 0 ]]; then
         case "$1" in
             -h|--h|--he|--hel|--help)
                 moUsage "$0"
                 exit 0
+                ;;
+
+            --source=*)
+                . "${1#--source=}"
+                shift 1
                 ;;
         esac
     fi

--- a/tests/source.expected
+++ b/tests/source.expected
@@ -1,0 +1,5 @@
+value
+* 1
+* 2
+* 3
+AAA BBB

--- a/tests/source.sh
+++ b/tests/source.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+cd "${0%/*}"
+cat <<EOF | ../mo --source=source.vars
+{{VAR}}
+{{#ARR}}
+* {{.}}
+{{/ARR}}
+{{ASSOC_ARR.a}} {{ASSOC_ARR.b}}
+EOF
+
+
+# Prints the string should mo NOT fail. Meaning that the output will not match
+# tests/source.expected and therefore the test will fail.
+
+../mo --source=a/non/existent/file files >/dev/null 2>&1
+[[ "$?" -ne 1 ]] && echo "mo accepted a non existent file"

--- a/tests/source.vars
+++ b/tests/source.vars
@@ -1,0 +1,4 @@
+export VAR=value
+export ARR=(1 2 3)
+declare -A ASSOC_ARR
+export ASSOC_ARR=([a]=AAA [b]=BBB)


### PR DESCRIPTION
Hi,

With this commit one can pass a "--source=/path/to/script' option to mo and it
will source the script before parsing any templates. For an example of this in
practice see demo/sourcing.

This is particularly useful if want to use arrays but you can't source mo due to
the shell being incompatible. For instance ZSH.
