### PR TITLE
Change variable testing behaviour

### DIFF
--- a/mo
+++ b/mo
@@ -775,15 +775,14 @@ moStandaloneDenied() {
 
 
 # Internal: Determines if the named thing is a function or if it is a
-# non-empty environment variable.
+# non-empty, not false environment variable.
 #
 # Do not use variables without prefixes here if possible as this needs to
 # check if any name exists in the environment
 #
 # $1 - Name of environment variable or function
-# $2 - Current value (our context)
 #
-# Returns 0 if the name is not empty, 1 otherwise.
+# Returns 0 if the name is not empty nor false, 1 otherwise.
 moTest() {
     # Test for functions
     moIsFunction "$1" && return 0
@@ -792,8 +791,8 @@ moTest() {
         # Arrays must have at least 1 element
         eval '[[ "${#'"$1"'[@]}" -gt 0 ]]' && return 0
     else
-        # Environment variables must not be empty
-        [[ ! -z "${!1}" ]] && return 0
+        # Environment variables must not be empty nor false
+        [[ ! -z "${!1}" ]] && eval '[[ "$'"$1"'" != "false" ]]'  && return 0
     fi
 
     return 1

--- a/tests/false-list.env
+++ b/tests/false-list.env
@@ -1,1 +1,2 @@
 person=""
+falsy=false

--- a/tests/false-list.template
+++ b/tests/false-list.template
@@ -2,3 +2,6 @@ Shown.
 {{#person}}
   Never shown!
 {{/person}}
+{{#falsy}}
+  As well !
+{{/falsy}}


### PR DESCRIPTION
Hi there !

   It might not be an acceptable behaviour regarding Mustache specs but here is my use case:
   I intend to use ```mo``` in a Docker Image in order to build specific configuration files based on some Env variables (at runtime then).

   I am really attracted by ```mo``` because it's so small, fits well in an Alpine based image and got the small sets of features I need (Conditionals mainly).

   However, I had like to support the fact that people might want part of the configuration to be deactivated when using such syntax: ```SYSTEM_ENABLED=false```

   So here a Pull Request if you are interested but I would totally get that supporting the value "false" make much more sense in the context of this tool.
   If there is an alternative way to support my use case within Mustache (Using a command line argument for example), I had be glad to make the change.

Thanks