### PR TITLE
fix: show latest version for usage of mo

### DIFF
--- a/mo
+++ b/mo
@@ -1052,7 +1052,7 @@ moUsage() {
 
 # Save the original command's path for usage later
 MO_ORIGINAL_COMMAND="$(cd "${BASH_SOURCE[0]%/*}" || exit 1; pwd)/${BASH_SOURCE[0]##*/}"
-MO_VERSION="2.0.4"
+MO_VERSION="2.1.0"
 
 # If sourced, load all functions.
 # If executed, perform the actions as expected.


### PR DESCRIPTION
### Overview

Currently, the latest version for `mo` is [v2.1.0](https://github.com/tests-always-included/mo/tree/2.1.0). But usage shows the previous version (v2.0.4).