### PR TITLE
Updated function calls to pass in current element when looping

### DIFF
--- a/demo/associative-arrays
+++ b/demo/associative-arrays
@@ -14,6 +14,6 @@ Accessing data directly:
 
 Things in DATA:
 {{#DATA}}
-    Item: {{.}}
+    {{$}}: {{.}}
 {{/DATA}}
 EOF

--- a/demo/associative-cross-arrays
+++ b/demo/associative-cross-arrays
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cd "$(dirname "$0")" # Go to the script's directory
+
+declare -A DATA OTHER_DATA NUM_DATA
+DATA=([one]=111 [two]=222)
+
+# Lookup another array using same keys
+OTHER_DATA=([one]="!!!" [two]="@@@")
+
+# Lookup another array using value as key
+NUM_DATA=([111]="One" [222]="Two")
+
+. ../mo
+
+cat <<EOF | mo
+Accessing data directly:
+    DATA: {{DATA}}
+    One: {{DATA.one}}
+    Two: {{DATA.two}}
+
+Things in DATA:
+{{#DATA}}
+    DATA: {{$}}: {{.}}
+    OTHER_DATA: {{$}}: {{OTHER_DATA[$]}}
+    NUM_DATA: {{.}}: {{NUM_DATA[.]}}
+{{/DATA}}
+EOF

--- a/demo/function-args-loops
+++ b/demo/function-args-loops
@@ -3,35 +3,37 @@
 
 cd "$(dirname "$0")" # Go to the script's directory
 
-# The links are associative arrays
-declare -a links
-declare -A names urls
+MO_ALLOW_FUNCTION_ARGUMENTS=true
 
-links+=(resque)
+# The links are associative arrays
+#declare -a links
+declare -A names urls links pewpew
+
+pewpew[test1]=test1.1
+pewpew[test2]=test2.2
+pewpew[test3]=test3.3
+
+links[foo]=resque
 names[resque]=Resque
 urls[resque]=http://example.com/resque
 
-links+=(hub)
+links[bar]=hub
 names[hub]=Hub
 urls[hub]=http://example.com/hub
 
-links+=(rip)
+links[quux]=rip
 names[rip]=Rip
 urls[rip]=http://example.com/rip
 
 # helper functions
 link_name() {
-    # Trying to use unique names
-    local key
-    key=$(cat)
-    echo ${names[$key]}
+    echo "$@" >&2
+    echo ${names[$3]}
 }
 
 link_url() {
-    # Trying to use unique names
-    local key
-    key=$(cat)
-    echo ${urls[$key]}
+    echo "$@" >&2
+    echo ${urls[$2]}
 }
 
 
@@ -41,8 +43,8 @@ link_url() {
 # Process the template
 cat <<EOF | mo --allow-function-arguments
 Here are your links:
-{{#links}}
- * [{{link_name}}]({{link_url}})
-{{/links}}
+{{#pewpew}}{{#links}}
+ * [{{link_name test}}]({{link_url}})
+{{/links}}{{/pewpew}}
 
 EOF

--- a/demo/function-args-loops
+++ b/demo/function-args-loops
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Example for how #54 can get implemented.
+
+cd "$(dirname "$0")" # Go to the script's directory
+
+# The links are associative arrays
+declare -a links
+declare -A names urls
+
+links+=(resque)
+names[resque]=Resque
+urls[resque]=http://example.com/resque
+
+links+=(hub)
+names[hub]=Hub
+urls[hub]=http://example.com/hub
+
+links+=(rip)
+names[rip]=Rip
+urls[rip]=http://example.com/rip
+
+# helper functions
+link_name() {
+    # Trying to use unique names
+    local key
+    key=$(cat)
+    echo ${names[$key]}
+}
+
+link_url() {
+    # Trying to use unique names
+    local key
+    key=$(cat)
+    echo ${urls[$key]}
+}
+
+
+# Source mo in order to work with arrays
+. ../mo
+
+# Process the template
+cat <<EOF | mo --allow-function-arguments
+Here are your links:
+{{#links}}
+ * [{{link_name}}]({{link_url}})
+{{/links}}
+
+EOF

--- a/demo/function-args-loops
+++ b/demo/function-args-loops
@@ -1,50 +1,34 @@
 #!/usr/bin/env bash
-# Example for how #54 can get implemented.
+#
+# This shows the key and value of an array element being appended
+# to a function call's arguments list
 
 cd "$(dirname "$0")" # Go to the script's directory
 
-MO_ALLOW_FUNCTION_ARGUMENTS=true
-
-# The links are associative arrays
-#declare -a links
-declare -A names urls links pewpew
-
-pewpew[test1]=test1.1
-pewpew[test2]=test2.2
-pewpew[test3]=test3.3
-
-links[foo]=resque
-names[resque]=Resque
-urls[resque]=http://example.com/resque
-
-links[bar]=hub
-names[hub]=Hub
-urls[hub]=http://example.com/hub
-
-links[quux]=rip
-names[rip]=Rip
-urls[rip]=http://example.com/rip
-
-# helper functions
-link_name() {
-    echo "$@" >&2
-    echo ${names[$3]}
-}
-
-link_url() {
-    echo "$@" >&2
-    echo ${urls[$2]}
-}
-
-
-# Source mo in order to work with arrays
+declare -A DATA
+DATA=([one]=111 [two]=222)
 . ../mo
 
-# Process the template
-cat <<EOF | mo --allow-function-arguments
-Here are your links:
-{{#pewpew}}{{#links}}
- * [{{link_name test}}]({{link_url}})
-{{/links}}{{/pewpew}}
+declare -a OTHER_DATA
+OTHER_DATA=(foo bar)
 
+LIST_ITEM() {
+    echo "- $1: $2"
+}
+
+SPECIAL_LIST_ITEM() {
+    echo "- [$1](./?item=$2): $3"
+}
+
+cat <<EOF | mo --allow-function-arguments
+Accessing data directly:
+    DATA: {{DATA}}
+    One: {{DATA.one}}
+    Two: {{DATA.two}}
+
+Things in DATA:
+{{#DATA}}
+    {{LIST_ITEM}}
+    {{SPECIAL_LIST_ITEM Click}}
+{{/DATA}}
 EOF

--- a/demo/using-deep-arrays
+++ b/demo/using-deep-arrays
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Example for how #54 can get implemented.
+
+cd "$(dirname "$0")" # Go to the script's directory
+
+MO_ALLOW_FUNCTION_ARGUMENTS=true
+
+# The links are associative arrays
+declare -a sections
+declare -A homeSection otherSection
+declare -A resqueLink hubLink ripLink
+
+resqueLink[title]="Resque"
+resqueLink[url]="http://example.com/resque"
+
+hubLink[title]="Hub"
+hubLink[url]="http://example.com/hub"
+
+ripLink[title]="Rip"
+ripLink[url]="http://example.com/rip"
+
+# By declaring `links` as an array
+# the `links` sub-elements will be
+# treated as arrays instead of strings
+declare -a links
+homeSection[name]="Home Section"
+homeSection[links]="resqueLink hubLink"
+
+otherSection[name]="Other Section"
+otherSection[links]="ripLink"
+
+sections=(homeSection otherSection)
+
+# Source mo in order to work with arrays
+. ../mo
+
+# Process the template
+cat <<EOF | mo --allow-function-arguments
+{{#sections}}
+# {{name}}
+
+{{links}}
+
+{{#links}}
+- [{{title}}]({{url}})
+{{/links}}
+
+{{/sections}}
+
+EOF

--- a/mo
+++ b/mo
@@ -497,6 +497,20 @@ moExpandAssoc() {
     done
 }
 
+
+# Internal: Cleans the values from a previous expanded assoc
+#
+# $1 - Array name
+#
+# Returns nothing.
+moCleanExpanded() {
+    local moKeys moValue moValueArr
+    moKeys=($(eval 'echo "${!'$1'[@]}"'))
+    for k in "${moKeys[@]}"; do
+        unset -v "$k"
+    done
+}
+
 # Internal: Scans a string to determine if all elements are declared arrays
 #
 # $1-@ - Array elements
@@ -818,6 +832,8 @@ moParse() {
                             moCurContext=$(moAppendContext "$moContext" "$k" "$moValue")
 
                             moParse "${moBlock[0]}" "$moFullKey" false "$moCurContext"
+
+                            moCleanExpanded "$moValue"
                         done;
                     else
                         moParse "${moBlock[0]}" "$moCurrent" true "$moContext"

--- a/mo
+++ b/mo
@@ -769,9 +769,13 @@ moParse() {
                 moFullTagName moTag "$moCurrent" "$moTag"
                 moContent=${moContent[1]}
 
+                if [[ ! -z "$moCurrent" ]]; then
+                    moBlock=$(moShow "$moCurrent" "$moCurrent")
+                fi
+
                 # Now show the value
                 # Quote moArgs here, do not quote it later.
-                moShow "$moTag" "$moCurrent" "$moArgs"
+                moShow "$moTag" "$moCurrent" "$moArgs" "$moBlock"
                 ;;
 
             '&'*)
@@ -791,8 +795,12 @@ moParse() {
                 moArgs=${moArgs:${#moTag}}
                 moFullTagName moTag "$moCurrent" "$moTag"
 
+                if [[ ! -z "$moCurrent" ]]; then
+                    moBlock=$(moShow "$moCurrent" "$moCurrent")
+                fi
+
                 # Quote moArgs here, do not quote it later.
-                moShow "$moTag" "$moCurrent" "$moArgs"
+                moShow "$moTag" "$moCurrent" "$moArgs" "$moBlock"
                 ;;
         esac
 
@@ -880,6 +888,7 @@ moPartial() {
 # $1 - Name of environment variable or function
 # $2 - Current context
 # $3 - Arguments string if $1 is a function
+# $4 - Content string if $1 is a function
 #
 # Returns nothing.
 moShow() {
@@ -887,7 +896,7 @@ moShow() {
     local moJoined moNameParts moContent
 
     if moIsFunction "$1"; then
-        moCallFunction moContent "$1" "" "$3"
+        moCallFunction moContent "$1" "$4" "$3"
         moParse "$moContent" "$2" false
         return 0
     fi

--- a/tests/function-args-loop.env
+++ b/tests/function-args-loop.env
@@ -1,0 +1,9 @@
+arr=(
+    "test1"
+    "test2"
+)
+
+testArgs() {
+    value=$(cat)
+    echo "$value - $MO_FUNCTION_ARGS"
+}

--- a/tests/function-args-loop.env
+++ b/tests/function-args-loop.env
@@ -1,9 +1,11 @@
-arr=(
-    "test1"
-    "test2"
+arr1=(
+    "foo1"
+)
+arr2=(
+    "foo2"
+    "bar2"
 )
 
 testArgs() {
-    value=$(cat)
-    echo "$value - $MO_FUNCTION_ARGS"
+    echo "$MO_FUNCTION_ARGS ${MO_LOOP_KEYS[0]} ${MO_LOOP[0]}"
 }

--- a/tests/function-args-loop.expected
+++ b/tests/function-args-loop.expected
@@ -1,8 +1,10 @@
-No args: [test1 - ] - done
-One arg: [test1 - one] - done
-Multiple arguments: [test1 - aa bb cc 'x' " ! {[_.|] - done
-Evil: [test1 - bla; cat /etc/issue] - done
-No args: [test2 - ] - done
-One arg: [test2 - one] - done
-Multiple arguments: [test2 - aa bb cc 'x' " ! {[_.|] - done
-Evil: [test2 - bla; cat /etc/issue] - done
+
+No args: 0: foo2 [ 0 foo2] - done
+One arg: 0: foo2 [one 0 foo2] - done
+Multiple arguments: 0: foo2 [aa bb cc 'x' " ! {[_.| 0 foo2] - done
+Evil: 0: foo2 [bla; cat /etc/issue 0 foo2] - done
+
+No args: 1: bar2 [ 1 bar2] - done
+One arg: 1: bar2 [one 1 bar2] - done
+Multiple arguments: 1: bar2 [aa bb cc 'x' " ! {[_.| 1 bar2] - done
+Evil: 1: bar2 [bla; cat /etc/issue 1 bar2] - done

--- a/tests/function-args-loop.expected
+++ b/tests/function-args-loop.expected
@@ -1,0 +1,8 @@
+No args: [test1 - ] - done
+One arg: [test1 - one] - done
+Multiple arguments: [test1 - aa bb cc 'x' " ! {[_.|] - done
+Evil: [test1 - bla; cat /etc/issue] - done
+No args: [test2 - ] - done
+One arg: [test2 - one] - done
+Multiple arguments: [test2 - aa bb cc 'x' " ! {[_.|] - done
+Evil: [test2 - bla; cat /etc/issue] - done

--- a/tests/function-args-loop.template
+++ b/tests/function-args-loop.template
@@ -1,0 +1,6 @@
+{{#arr}}
+No args: [{{testArgs}}] - done
+One arg: [{{testArgs one}}] - done
+Multiple arguments: [{{testArgs aa bb cc 'x' " ! {[_.| }}] - done
+Evil: [{{testArgs bla; cat /etc/issue}}] - done
+{{/arr}}

--- a/tests/function-args-loop.template
+++ b/tests/function-args-loop.template
@@ -1,6 +1,8 @@
-{{#arr}}
-No args: [{{testArgs}}] - done
-One arg: [{{testArgs one}}] - done
-Multiple arguments: [{{testArgs aa bb cc 'x' " ! {[_.| }}] - done
-Evil: [{{testArgs bla; cat /etc/issue}}] - done
-{{/arr}}
+{{#arr1}}
+{{#arr2}}
+No args: {{$}}: {{.}} [{{testArgs}}] - done
+One arg: {{$}}: {{.}} [{{testArgs one}}] - done
+Multiple arguments: {{$}}: {{.}} [{{testArgs aa bb cc 'x' " ! {[_.| }}] - done
+Evil: {{$}}: {{.}} [{{testArgs bla; cat /etc/issue}}] - done
+{{/arr2}}
+{{/arr1}}


### PR DESCRIPTION
> ~This pipes in the current element of an array loop into a non-block function call.~
> 
> ~This greatly simplifies loops and streamlines lookup functions.~


_**Click the arrows below to see examples.**_

Many improvements around arrays. I'll try my best to describe them in detail here:

### Output Key of Array

<details>
<summary>Added `{{$}}` syntax to output the key of the element. Useful for Associative Arrays:</summary>

#### Example:
```bash
declare -A myArray
myArray[foo]=bar

{{#myArray}}
- {{$}}: {{.}}
{{/myArray}}
```

#### Outputs:
```markdown
- foo: bar
```

</details>

### Cross-reference Associative Arrays:

<details>
<summary>Reference a sister-array using the key of the first array:</summary>

#### Example:
```bash
declare -A titles links
titles[foo]="Foo"
links[foo]="https://www.example.com/foo"

{{#links}}
- ({{titles[$]}})[{{.}}]
{{/links}}
```

#### Outputs:
```markdown
- [Foo](https://www.example.com/foo)
```

</details>

<details>
<summary>Reference a sister-array using the _value_ of the first array:</summary>

#### Example:
```bash
declare -A titles links
titles=(foo bar)
links[foo]="https://www.example.com/foo"
links[bar]="https://www.example.com/bar"

{{#titles}}
- ({{.}})[{{links[.]}}]
{{/titles}}
```

#### Outputs:
```markdown
- [foo](https://www.example.com/foo)
- [bar](https://www.example.com/bar)
```

</details>

### Expand Array of Associative Arrays to Scope

<details>
<summary>Use an associative array's keys as first-class variables</summary>

#### Example:
```bash
declare -a navItems
declare -A homeLink otherLink

homeLink[title]="Home"
homeLink[url]="https://www.example.com/home"

otherLink[title]="Other Link"
otherLink[url]="https://www.example.com/other-page"

navItems=(homeLink otherLink)

{{#navItems}}
- [{{title}}]({{url}})
{{/navItems}}
```

#### Outputs:
```markdown
- [Home](https://www.example.com/home)
- [Other Link](https://www.example.com/other-page)
```

</details>

### Expanded Associative Arrays can Reference Other Arrays

<details>
<summary>Reference other arrays within expanded associative arrays</summary>

#### Using `declare -a` for sub-elements
> By declaring the key of an element as an array, `mo` will now treat it as an array:
> ```bash
> declare -a links
> homeSections[links]="resqueLink hubLink" # <- Treated as an array
> ```

#### Example:

```bash
# Declare links
declare -A resqueLink hubLink ripLink

resqueLink[title]="Resque"
resqueLink[url]="http://example.com/resque"

hubLink[title]="Hub"
hubLink[url]="http://example.com/hub"

ripLink[title]="Rip"
ripLink[url]="http://example.com/rip"


# Declare sections
declare -a sections
declare -A homeSection otherSection
declare -a links # Declare [links] as array references

homeSection[name]="Home Section"
homeSection[links]="resqueLink hubLink"

otherSection[name]="Other Section"
otherSection[links]="ripLink"

sections=(homeSection otherSection)


{{#sections}}
# {{name}}

{{#links}}
- [{{title}}]({{url}})
{{/links}}

{{/sections}}
```

#### Outputs:
```markdown
# Home Section

- [Resque](http://example.com/resque)
- [Hub](http://example.com/hub)

# Other Section

ripLink

- [Rip](http://example.com/rip)
```

</details>

### Functions called within loops get the key and value that they're looping inside of as arguments

<details>
<summary>With `--allow-function-arguments`, the last two arguments passed to a function are the key and value respectively.</summary>

#### Example:
```bash

func1() {
    echo "- $2"
}

func2() {
    echo "- [$1 ~ $3]($2)"
}

declare -a arr
arr=(foo bar)

declare -A assoc
assoc[foo]="hello"
assoc[bar]="world"


{{#arr}}
{{func1}}
{{/arr}}

{{#assoc}}
{{func2 Arrrgh}}
{{/assoc}]
```

#### Outputs:
```markdown
- foo
- bar

- [Arrrgh - hello](foo)
- [Arrrgh - world](bar)
```

</details>

<details>
<summary>MO_LOOP and MO_LOOP_KEYS provide the key and value for the current element</summary>

#### Example:

> MO_LOOP and MO_LOOP_KEYS work like a stack, in that the zeroeth element is the _current_ value and key (respectively), and each element after that represents a level above it in the loop.

```bash
declare -A assoc
assoc[strawberry]="red"
assoc[watermelon]="green"

uppercaseKey() {
    echo "${MO_LOOP_KEYS[0]^^}"
}

uppercaseValue() {
    echo "${MO_LOOP[0]^^}"
}

{{#assoc}}
- a {{uppercaseKey}} is {{uppercaseValue}}
{{/assoc}}
```

#### Outputs:
```
- a STRAWBERRY is RED
- a WATERMELON is GREEN
```

</details>

<details>
<summary>MO_LOOP and MO_LOOP_KEYS provide a context stack for nested loops</summary>

#### Example:

> MO_LOOP and MO_LOOP_KEYS work like a stack, in that the zeroeth element is the _current_ value and key (respectively), and each element after that represents a level above it in the loop.

```bash
declare -A assoc
assoc[strawberry]="hello"
assoc[watermelon]="world"

declare -a arr
arr=(foo bar)

func() {
    echo "Key Stack: ${MO_LOOP_KEYS[@]}"
    echo "Value Stack: ${MO_LOOP[@]}"
}

{{#assoc}}
    {{#arr}}
        {{func}}
    {{/arr}}
{{/assoc}}
```

#### Outputs:
```
Key Stack: 0 strawberry
Value Stack: foo hello

Key Stack: 1 strawberry
Value Stack: foo hello

Key Stack: 0 watermelon
Value Stack: bar world

Key Stack: 1 watermelon
Value Stack: bar world
```

</details>
