### PR TITLE
Improved portability by using /usr/bin/env pragma

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ How to Use
 
 If you only plan using strings and numbers, nothing could be simpler.  In your shell script you can choose to export the variables.  The below script is [`demo/using-strings`](demo/using-strings).
 
-    #!/bin/bash
+    #!/usr/bin/env bash
     cd "$(dirname "$0")" # Go to the script's directory
     export TEST="This is a test"
     echo "Your message:  {{TEST}}" | ../mo
@@ -100,7 +100,7 @@ The result?  "Your message:  This is a test".
 
 Using arrays adds a slight level of complexity.  *You must source `mo`.*  Look at [`demo/using-arrays`](demo/using-arrays).
 
-    #!/bin/bash
+    #!/usr/bin/env bash
     cd "$(dirname "$0")" # Go to the script's directory
     export ARRAY=( one two "three three three" four five )
     . ../mo # This loads the "mo" function

--- a/demo/associative-arrays
+++ b/demo/associative-arrays
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")" # Go to the script's directory
 

--- a/demo/embedded-template
+++ b/demo/embedded-template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This embeds a template in the script without using strange `cat` syntax.
 

--- a/demo/function-args
+++ b/demo/function-args
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This sources a simple script with the env. variables needed for the template.
 

--- a/demo/function-for-advanced-looping
+++ b/demo/function-for-advanced-looping
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")" # Go to the script's directory
 

--- a/demo/function-for-building-json
+++ b/demo/function-for-building-json
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")" # Go to the script's directory
 

--- a/demo/important-file
+++ b/demo/important-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"/..
 

--- a/demo/sourcing
+++ b/demo/sourcing
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This sources a simple script with the env. variables needed for the template.
 

--- a/demo/using-arrays
+++ b/demo/using-arrays
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 cd "$(dirname "$0")" # Go to the script's directory
 export ARRAY=( one two "three three three" four five )
 . ../mo

--- a/demo/using-strings
+++ b/demo/using-strings
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This example does not source `mo` and is intentionally restricted to
 # variables that are not arrays.

--- a/make-api-doc
+++ b/make-api-doc
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This requires tomdoc.sh to be in your PATH.
 # https://github.com/tests-always-included/tomdoc.sh

--- a/run-spec.js
+++ b/run-spec.js
@@ -64,7 +64,7 @@ function runTest(test, done) {
     var output, partials, script;
 
     script = [
-        '#!/bin/bash'
+        '#!/usr/bin/env bash'
     ];
     partials = test.partials || {};
 


### PR DESCRIPTION
I'm not sure if this is desired, but I noticed a lot of inconsistencies throughout the code base with regard to pragma usage.

This updates all uses of `#!/bin/bash` to use the more portable `#!/usr/bin/env bash`.