### PR TITLE
Implemented strict mode to prevent insecure access to external variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 diagnostic.partial
 diagnostic.test
 tests/*.diff
+tests/*.actual
 spec/
 spec-runner/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -118,6 +118,18 @@ There are more scripts available in the [demos directory](demo/) that could help
 There are additional features that the program supports. Try using `mo --help` to see what is available.
 
 
+Security
+-----------
+
+Because `mo` uses environment variables that could be unsafe in the event that `mo` is invoked programmatically with user-input, `mo` provides `--strict` mode when used with `--source=`. `mo` will attempt to track variables that are created by each `--source=`'ed environment file, and will disallow access to external variables.
+
+To use this, `--strict` must be used with `--source=`:
+
+```bash
+./mo --strict --source=.env my-template.mustache
+```
+
+
 Concessions
 -----------
 

--- a/run-tests
+++ b/run-tests
@@ -23,6 +23,9 @@ for TEST in tests/*.expected; do
             . "${BASE}.env"
             echo "Do not read this input" | mo "${BASE}.template"
         fi
+    ) | (
+        cat > "${BASE}.actual";
+        cat "${BASE}.actual"
     ) | diff -U5 - "${TEST}" > "${BASE}.diff"
 
     statusCode=$?
@@ -34,6 +37,7 @@ for TEST in tests/*.expected; do
         echo "ok"
         PASS=$(( PASS + 1 ))
         rm "${BASE}.diff"
+        rm "${BASE}.actual"
     fi
 done
 

--- a/tests/source.expected
+++ b/tests/source.expected
@@ -1,3 +1,4 @@
+Purposely Unsafe for Backwards Compatibility
 value
 * 1
 * 2

--- a/tests/source.sh
+++ b/tests/source.sh
@@ -2,6 +2,7 @@
 
 cd "${0%/*}" || exit 1
 cat <<EOF | ../mo --source=source.vars
+{{#BASH}}Purposely Unsafe for Backwards Compatibility{{/BASH}}
 {{VAR}}
 {{#ARR}}
 * {{.}}

--- a/tests/strict-source-multiple-1.vars
+++ b/tests/strict-source-multiple-1.vars
@@ -1,0 +1,2 @@
+export A=from1
+export B=from1

--- a/tests/strict-source-multiple-2.vars
+++ b/tests/strict-source-multiple-2.vars
@@ -1,0 +1,3 @@
+export B=from2
+export C=from2
+declare -a -x D=(from2)

--- a/tests/strict-source-multiple.expected
+++ b/tests/strict-source-multiple.expected
@@ -1,0 +1,5 @@
+A: from1
+B: from2
+C: from2
+D: from2
+D: from2

--- a/tests/strict-source-multiple.sh
+++ b/tests/strict-source-multiple.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+cd "${0%/*}" || exit 1
+
+_CTRL_Z_=$'\cZ'
+
+{
+    IFS=$'\n'"${_CTRL_Z_}" read -r -d "${_CTRL_Z_}" STDERR;
+    IFS=$'\n'"${_CTRL_Z_}" read -r -d "${_CTRL_Z_}" STDOUT;
+} <<EOF
+$((printf "${_CTRL_Z_}%s${_CTRL_Z_}%d${_CTRL_Z_}" "$(\
+cat <<EOMO | ../mo --strict --source=strict-source-multiple-1.vars --source=strict-source-multiple-2.vars
+{{#BASH_VERSINFO}}Illegal{{/BASH_VERSINFO}}
+{{BASH_VERSINFO.0}}
+A: {{A}}
+B: {{B}}
+C: {{C}}
+D: {{D.0}}
+D: {{#D}}{{.}}{{/D}}
+EOMO
+)" "${?}" 1>&2) 2>&1)
+EOF
+
+echo "${STDOUT[@]}"
+
+expectedErr="Illegal variable access BASH_VERSINFO"
+if [[ ! "$STDERR" =~ "$expectedErr" ]]; then
+    echo "STDERR should have contained an illegal variable access message:"
+    echo "$STDERR"
+fi
+
+exit 0


### PR DESCRIPTION
Implements #52

Introduces `--strict` to prevent access to variables that weren't defined in sourced files

This _**only**_ works with `--source`. It's a no-op if it's set without `--source`.

Tested using `fidian/multishell-small`:
```
# run-script-againt-shells bash-3 ./run-tests
bash-3.1.23: pass
bash-3.2.57: pass

# run-script-againt-shells bash-4 ./run-tests
bash-4.0.44: pass
bash-4.1.17: pass
bash-4.2.53: pass
bash-4.3.48: pass
bash-4.4.23: pass

# run-script-againt-shells bash-5 ./run-tests
bash-5.0.18: pass
bash-5.1.8: pass
```

###### Minor addition
> In addition to these changes, I also introduced a `tests/*.actual` in addition to the `tests/*.diff` for debugging tests.