### PR TITLE
Subexpressions

### DIFF
--- a/mo
+++ b/mo
@@ -195,7 +195,7 @@ moCallFunction() {
     moArgs=()
     for (( m=0; m<${#MO_FUNCTION_ARGS[@]}; m++ )); do
         MO_FUNCTION_ARGS[$m]="$(moParse "(${MO_FUNCTION_ARGS[$m]})" "$3" "$3" true)"
-        moQuote moQuoted "${MO_FUNCTION_ARGS[$m]}"
+        moSanitize moQuoted "${MO_FUNCTION_ARGS[$m]}"
         moArgs+=($moQuoted)
     done
 
@@ -542,11 +542,17 @@ moUnescape() {
 # $2 - Content to quote
 #
 # Returns nothing.
-moQuote() {
-    #echo "FOR:       $1" >&2
-    #echo "UNQUOTED: >$2<" >&2
-    #echo "QUOTED:   >\"${2//\"/\\\"}\"<" >&2
-    local "$1" && moIndirect "$1" "\"${2//\"/\\\"}\""
+moSanitize() {
+    local moSanitized="${2//\\/\\\\}"         # Escape backslashes
+    moSanitized="${moSanitized//\$/\\\$}" # Escape dollar signs
+    moSanitized="${moSanitized//\"/\\\"}" # Escape double quotes
+    moSanitized="${moSanitized//\`/\\\`}" # Escape backticks
+    #moSanitized="${moSanitized//\*/\\*}"  # Escape asterisks
+    #moSanitized="${moSanitized//\}/\}}"  # Escape closing curly braces
+    #moSanitized="${moSanitized//\$\{/\$\{}"  # Escape opening curly braces
+    #moSanitized="${moSanitized//\{\!/\\!}"  # Escape exclamation marks
+    local "$1" && moIndirect "$1" "\"$moSanitized\""
+    #local "$1" && moIndirect "$1" "\"${2//\"/\\\"}\""
 }
 
 

--- a/run-tests
+++ b/run-tests
@@ -7,7 +7,7 @@ cd "${0%/*}" || exit 1
 PASS=0
 FAIL=0
 
-for TEST in tests/*.expected; do
+for TEST in tests/$1*.expected; do
     export BASE="${TEST%.expected}"
     export MO_FALSE_IS_EMPTY=
 
@@ -23,6 +23,9 @@ for TEST in tests/*.expected; do
             . "${BASE}.env"
             echo "Do not read this input" | mo "${BASE}.template"
         fi
+    ) | (
+        cat > "${BASE}.actual";
+        cat "${BASE}.actual"
     ) | diff -U5 - "${TEST}" > "${BASE}.diff"
 
     statusCode=$?
@@ -34,6 +37,7 @@ for TEST in tests/*.expected; do
         echo "ok"
         PASS=$(( PASS + 1 ))
         rm "${BASE}.diff"
+        rm "${BASE}.actual"
     fi
 done
 

--- a/tests/function-args-read.env
+++ b/tests/function-args-read.env
@@ -1,3 +1,5 @@
+MO_ALLOW_FUNCTION_ARGUMENTS=true
+
 testArgs() {
-    echo "$MO_FUNCTION_ARGS"
+    echo "$@"
 }

--- a/tests/function-args-read.template
+++ b/tests/function-args-read.template
@@ -1,4 +1,4 @@
 No args: [{{testArgs}}] - done
-One arg: [{{testArgs one}}] - done
-Multiple arguments: [{{testArgs aa bb cc 'x' " ! {[_.| }}] - done
-Evil: [{{testArgs bla; cat /etc/issue}}] - done
+One arg: [{{testArgs "one"}}] - done
+Multiple arguments: [{{testArgs "aa" "bb" "cc" "'x'" "\" ! {[_.|" }}] - done
+Evil: [{{testArgs "bla; cat /etc/issue"}}] - done

--- a/tests/function-args.template
+++ b/tests/function-args.template
@@ -1,4 +1,4 @@
 No args: {{testArgs}} - done
-One arg: {{testArgs one}} - done
+One arg: {{testArgs "one"}} - done
 Getting name in a string: {{testArgs "The name is $name"}} - done
-Reverse this: {{#pipeTo rev}}abcde{{/pipeTo}}
+Reverse this: {{#pipeTo "rev"}}abcde{{/pipeTo}}

--- a/tests/subexpressions.env
+++ b/tests/subexpressions.env
@@ -1,0 +1,21 @@
+x="repo"
+i=2
+repo=( "resque" "hub" "rip" )
+quote() {
+    echo "'${MO_FUNCTION_ARGS[@]}'"
+}
+double_quote() {
+    echo "\"${MO_FUNCTION_ARGS[@]}\""
+}
+inter_examp() {
+    args=($MO_FUNCTION_ARGS)
+    first_t=${args[0]}
+    second_t=${args[1]}
+    first_v=${args[2]}
+    second_v=${args[3]}
+
+    [[ "$first_t" == "true" ]] && echo -n "$first_v "
+    [[ "$second_t" == "true" ]] && echo -n "$second_v "
+}
+exists="hello"
+#doesnt="foo"

--- a/tests/subexpressions.env
+++ b/tests/subexpressions.env
@@ -1,3 +1,5 @@
+MO_ALLOW_FUNCTION_ARGUMENTS=true
+
 x="repo"
 i=2
 repo=( "resque" "hub" "rip" )
@@ -8,14 +10,16 @@ double_quote() {
     echo "\"${MO_FUNCTION_ARGS[@]}\""
 }
 inter_examp() {
-    args=($MO_FUNCTION_ARGS)
-    first_t=${args[0]}
-    second_t=${args[1]}
-    first_v=${args[2]}
-    second_v=${args[3]}
+    #for v in "$@"; do
+    #    echo "> $v"
+    #done
+    first_t="$1"
+    second_t="$2"
+    first_v="$3"
+    second_v="$4"
 
-    [[ "$first_t" == "true" ]] && echo -n "$first_v "
-    [[ "$second_t" == "true" ]] && echo -n "$second_v "
+    [[ $first_t == true ]] && echo -n "$first_v "
+    [[ $second_t == true ]] && echo -n "$second_v "
 }
 exists="hello"
 #doesnt="foo"

--- a/tests/subexpressions.expected
+++ b/tests/subexpressions.expected
@@ -1,0 +1,9 @@
+Function: 'repo'
+Specific Element: rip
+Loop:
+  <b>"'resque'" resque</b>
+  <b>"'hub'" hub</b>
+  <b>"'rip'" rip</b>
+
+hello world 
+X: repo

--- a/tests/subexpressions.expected
+++ b/tests/subexpressions.expected
@@ -5,5 +5,5 @@ Loop:
   <b>"'hub'" hub</b>
   <b>"'rip'" rip</b>
 
-hello world 
+hello world help me "escape ! 
 X: repo

--- a/tests/subexpressions.template
+++ b/tests/subexpressions.template
@@ -1,0 +1,9 @@
+Function: {{quote (x)}}
+Specific Element: {{repo.(i)}}
+Loop:
+{{#repo}}
+  <b>{{double_quote (quote (.))}} {{.}}</b>
+{{/repo}}
+
+{{inter_examp (#exists) (^doesnt) (exists) world}}
+X: {{x}}

--- a/tests/subexpressions.template
+++ b/tests/subexpressions.template
@@ -1,9 +1,9 @@
-Function: {{quote (x)}}
+Function: {{quote x}}
 Specific Element: {{repo.(i)}}
 Loop:
 {{#repo}}
-  <b>{{double_quote (quote (.))}} {{.}}</b>
+  <b>{{double_quote "(quote .)"}} {{.}}</b>
 {{/repo}}
 
-{{inter_examp (#exists) (^doesnt) (exists) world}}
+{{inter_examp (#exists) (^doesnt) exists "world help me \"escape !" exists "testing"}}
 X: {{x}}


### PR DESCRIPTION
Implements #63 

Tested with `fidian/multishell-small`:
```bash
# run-script-againt-shells bash-3 ./run-tests
bash-3.1.23: pass
bash-3.2.57: pass

# run-script-againt-shells bash-4 ./run-tests
bash-4.0.44: pass
bash-4.1.17: pass
bash-4.2.53: pass
bash-4.3.48: pass
bash-4.4.23: pass

# run-script-againt-shells bash-5 ./run-tests
bash-5.0.18: pass
bash-5.1.8: pass
```